### PR TITLE
Trigger build workflow on push to master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,6 @@ name: Rust
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION
Trigger build workflow on push to master only, and not on opened PRs.