### PR TITLE
Add install of libssl-dev to post merge action

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Install musl-tools
-      run: sudo apt install musl-tools -y
+    - name: Install required tools
+      run: sudo apt install musl-tools libssl-dev -y
     - name: Add target
       run: rustup target add x86_64-unknown-linux-musl
     - name: Build

--- a/README.md
+++ b/README.md
@@ -2,5 +2,8 @@
 App to show public transport and weather for a given coordinate.
 
 ## Prerequisites
- - musl-tools (for building lambda)
+ - musl-tools
+   - For building lambda
+ - libssl-dev
+   - For creating release build on Ubuntu (not sure about Arch Linux yet..)
 


### PR DESCRIPTION
Add install of libssl-dev to post merge action
Seems to be required for rust-openssl (which I think is a dependency of rust-curl)