### PR TITLE
Remove AWS_REGION variable

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -55,7 +55,6 @@ Resources:
       Timeout: 10
       Environment:
         Variables:
-          AWS_REGION: !Ref AWS::Region
           STORAGE_BUCKET: !Ref DashboardStorageBucket
           DARK_SKY_API_KEY: !Ref DarkSkyApiKey
   DashboardStorageBucket:


### PR DESCRIPTION
Since it's a reserved key and present by default